### PR TITLE
Release candidate 1

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -260,6 +260,12 @@ stages:
             pool:
               vmImage: ubuntu-latest
             steps:
+            # Install the nuget tool.
+            - task: NuGetToolInstaller@0
+              displayName: 'Use NuGet >=5.2.0'
+              inputs:
+                versionSpec: '>=5.2.0'
+                checkLatest: true
             - task: DownloadPipelineArtifact@2
               displayName: Download nupkg from artifacts
               inputs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.0.0-rc.1] - 2022-12-15
+
+### Changed
+
+- Release candidate 1
+
 ## [1.0.0-preview.4] - 2022-09-02
 
 ### Added

--- a/Microsoft.Kiota.Serialization.Text.Tests/Microsoft.Kiota.Serialization.Text.Tests.csproj
+++ b/Microsoft.Kiota.Serialization.Text.Tests/Microsoft.Kiota.Serialization.Text.Tests.csproj
@@ -13,6 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.4.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Microsoft.Kiota.Serialization.Text.Tests/Microsoft.Kiota.Serialization.Text.Tests.csproj
+++ b/Microsoft.Kiota.Serialization.Text.Tests/Microsoft.Kiota.Serialization.Text.Tests.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
     <Nullable>enable</Nullable>
-
+    <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Microsoft.Kiota.Serialization.Text.csproj
+++ b/src/Microsoft.Kiota.Serialization.Text.csproj
@@ -13,7 +13,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>preview.4</VersionSuffix>
+    <VersionSuffix>rc.1</VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <SignAssembly>false</SignAssembly>
     <DelaySign>false</DelaySign>
@@ -22,15 +22,16 @@
     <!-- Enable this line once we go live to prevent breaking changes -->
     <!-- <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion> -->
     <PackageReleaseNotes>
-        - Adds support for composed types serialization
+        - Release Candidate 1
     </PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.0-preview.19" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.0-rc.1" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
@@ -39,6 +40,10 @@
 
   <ItemGroup>
     <None Include="..\LICENSE">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+    <None Include="..\README.md">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>


### PR DESCRIPTION
This PR creates a release candidate release for the library

Changes include -
- Ensure the nuget push task uses version greater than 5.2.0 to ensure debug symbols are pushed
- Include readme in nuget package in accordance with https://devblogs.microsoft.com/nuget/add-a-readme-to-your-nuget-package/
- Adds `net462` target to the test project so that project is tested against NetFramework as well.