### PR TITLE
Adds support for nullable reference types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+
+## [1.0.0-rc.2] - 2023-01-17
+
+### Changed
+
+- Adds support for nullable reference types
+
 ## [1.0.0-rc.1] - 2022-12-15
 
 ### Changed

--- a/src/Microsoft.Kiota.Serialization.Text.csproj
+++ b/src/Microsoft.Kiota.Serialization.Text.csproj
@@ -5,7 +5,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>Text/plain serialization Kiota library for dotnet</AssemblyTitle>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota-serialization-text-dotnet</RepositoryUrl>

--- a/src/Microsoft.Kiota.Serialization.Text.csproj
+++ b/src/Microsoft.Kiota.Serialization.Text.csproj
@@ -5,7 +5,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>Text/plain serialization Kiota library for dotnet</AssemblyTitle>
     <Authors>Microsoft</Authors>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota-serialization-text-dotnet</RepositoryUrl>
@@ -13,17 +13,20 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>rc.1</VersionSuffix>
+    <VersionSuffix>rc.2</VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <SignAssembly>false</SignAssembly>
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <!-- Enable this line once we go live to prevent breaking changes -->
     <!-- <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion> -->
     <PackageReleaseNotes>
-        - Release Candidate 1
-    </PackageReleaseNotes>
+		https://github.com/microsoft/kiota-serialization-text-dotnet/releases
+	</PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -31,7 +34,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.0-rc.3" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.0-rc.4" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">

--- a/src/TextParseNode.cs
+++ b/src/TextParseNode.cs
@@ -11,23 +11,23 @@ namespace Microsoft.Kiota.Serialization.Text;
 public class TextParseNode : IParseNode
 {
     internal const string NoStructuredDataMessage = "text does not support structured data";
-    private readonly string Text;
+    private readonly string? Text;
     /// <summary>
     /// Initializes a new instance of the <see cref="TextParseNode"/> class.
     /// </summary>
     /// <param name="text">The text value.</param>
-    public TextParseNode(string text)
+    public TextParseNode(string? text)
     {
         Text = text?.Trim('"');
     }
     /// <inheritdoc />
-    public Action<IParsable> OnBeforeAssignFieldValues { get; set; }
+    public Action<IParsable>? OnBeforeAssignFieldValues { get; set; }
     /// <inheritdoc />
-    public Action<IParsable> OnAfterAssignFieldValues { get; set; }
+    public Action<IParsable>? OnAfterAssignFieldValues { get; set; }
     /// <inheritdoc />
     public bool? GetBoolValue() => bool.TryParse(Text, out var result) ? result : null;
     /// <inheritdoc />
-    public byte[] GetByteArrayValue() => string.IsNullOrEmpty(Text) ? null : Convert.FromBase64String(Text);
+    public byte[]? GetByteArrayValue() => string.IsNullOrEmpty(Text) ? null : Convert.FromBase64String(Text);
     /// <inheritdoc />
     public byte? GetByteValue() => byte.TryParse(Text, out var result) ? result : null;
     /// <inheritdoc />
@@ -57,7 +57,7 @@ public class TextParseNode : IParseNode
     /// <inheritdoc />
     public sbyte? GetSbyteValue() => sbyte.TryParse(Text, out var result) ? result : null;
     /// <inheritdoc />
-    public string GetStringValue() => Text;
+    public string? GetStringValue() => Text;
     /// <inheritdoc />
     public TimeSpan? GetTimeSpanValue() => string.IsNullOrEmpty(Text) ? null : XmlConvert.ToTimeSpan(Text);
     /// <inheritdoc />

--- a/src/TextSerializationWriter.cs
+++ b/src/TextSerializationWriter.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Xml;
 using Microsoft.Kiota.Abstractions;
 using Microsoft.Kiota.Abstractions.Serialization;
-using System.Text;
 using Microsoft.Kiota.Abstractions.Extensions;
 using System.Linq;
 
@@ -25,11 +24,11 @@ public class TextSerializationWriter : ISerializationWriter, IDisposable {
     }
     private bool written;
     /// <inheritdoc />
-    public Action<IParsable> OnBeforeObjectSerialization { get; set; }
+    public Action<IParsable>? OnBeforeObjectSerialization { get; set; }
     /// <inheritdoc />
-    public Action<IParsable> OnAfterObjectSerialization { get; set; }
+    public Action<IParsable>? OnAfterObjectSerialization { get; set; }
     /// <inheritdoc />
-    public Action<IParsable, ISerializationWriter> OnStartObjectSerialization { get; set; }
+    public Action<IParsable, ISerializationWriter>? OnStartObjectSerialization { get; set; }
     /// <inheritdoc />
     public void Dispose()
     {
@@ -45,39 +44,39 @@ public class TextSerializationWriter : ISerializationWriter, IDisposable {
     /// <inheritdoc />
     public void WriteAdditionalData(IDictionary<string, object> value) => throw new InvalidOperationException(TextParseNode.NoStructuredDataMessage);
     /// <inheritdoc />
-    public void WriteBoolValue(string key, bool? value) => WriteStringValue(key, value?.ToString());
+    public void WriteBoolValue(string? key, bool? value) => WriteStringValue(key, value?.ToString());
     /// <inheritdoc />
-    public void WriteByteArrayValue(string key, byte[] value) => WriteStringValue(key, value.Any() ? Convert.ToBase64String(value) : string.Empty);
+    public void WriteByteArrayValue(string? key, byte[]? value) => WriteStringValue(key, value?.Any() ?? false ? Convert.ToBase64String(value) : string.Empty);
     /// <inheritdoc />
-    public void WriteByteValue(string key, byte? value) => WriteStringValue(key, value?.ToString());
+    public void WriteByteValue(string? key, byte? value) => WriteStringValue(key, value?.ToString());
     /// <inheritdoc />
-    public void WriteCollectionOfObjectValues<T>(string key, IEnumerable<T> values) where T : IParsable => throw new InvalidOperationException(TextParseNode.NoStructuredDataMessage);
+    public void WriteCollectionOfObjectValues<T>(string? key, IEnumerable<T>? values) where T : IParsable => throw new InvalidOperationException(TextParseNode.NoStructuredDataMessage);
     /// <inheritdoc />
-    public void WriteCollectionOfPrimitiveValues<T>(string key, IEnumerable<T> values) => throw new InvalidOperationException(TextParseNode.NoStructuredDataMessage);
+    public void WriteCollectionOfPrimitiveValues<T>(string? key, IEnumerable<T>? values) => throw new InvalidOperationException(TextParseNode.NoStructuredDataMessage);
     /// <inheritdoc />
-    public void WriteDateTimeOffsetValue(string key, DateTimeOffset? value) => WriteStringValue(key, value.HasValue ? value.Value.ToString() : null);
+    public void WriteDateTimeOffsetValue(string? key, DateTimeOffset? value) => WriteStringValue(key, value.HasValue ? value.Value.ToString() : null);
     /// <inheritdoc />
-    public void WriteDateValue(string key, Date? value) => WriteStringValue(key, value?.ToString());
+    public void WriteDateValue(string? key, Date? value) => WriteStringValue(key, value?.ToString());
     /// <inheritdoc />
-    public void WriteDecimalValue(string key, decimal? value) => WriteStringValue(key, value?.ToString());
+    public void WriteDecimalValue(string? key, decimal? value) => WriteStringValue(key, value?.ToString());
     /// <inheritdoc />
-    public void WriteDoubleValue(string key, double? value) => WriteStringValue(key, value?.ToString());
+    public void WriteDoubleValue(string? key, double? value) => WriteStringValue(key, value?.ToString());
     /// <inheritdoc />
-    public void WriteFloatValue(string key, float? value) => WriteStringValue(key, value?.ToString());
+    public void WriteFloatValue(string? key, float? value) => WriteStringValue(key, value?.ToString());
     /// <inheritdoc />
-    public void WriteGuidValue(string key, Guid? value) => WriteStringValue(key, value?.ToString());
+    public void WriteGuidValue(string? key, Guid? value) => WriteStringValue(key, value?.ToString());
     /// <inheritdoc />
-    public void WriteIntValue(string key, int? value) => WriteStringValue(key, value?.ToString());
+    public void WriteIntValue(string? key, int? value) => WriteStringValue(key, value?.ToString());
     /// <inheritdoc />
-    public void WriteLongValue(string key, long? value) => WriteStringValue(key, value?.ToString());
+    public void WriteLongValue(string? key, long? value) => WriteStringValue(key, value?.ToString());
     /// <inheritdoc />
-    public void WriteNullValue(string key) => WriteStringValue(key, "null");
+    public void WriteNullValue(string? key) => WriteStringValue(key, "null");
     /// <inheritdoc />
-    public void WriteObjectValue<T>(string key, T value, params IParsable[] additionalValuesToMerge) where T : IParsable => throw new InvalidOperationException(TextParseNode.NoStructuredDataMessage);
+    public void WriteObjectValue<T>(string? key, T? value, params IParsable[] additionalValuesToMerge) where T : IParsable => throw new InvalidOperationException(TextParseNode.NoStructuredDataMessage);
     /// <inheritdoc />
-    public void WriteSbyteValue(string key, sbyte? value) => WriteStringValue(key, value?.ToString());
+    public void WriteSbyteValue(string? key, sbyte? value) => WriteStringValue(key, value?.ToString());
     /// <inheritdoc />
-    public void WriteStringValue(string key, string value)
+    public void WriteStringValue(string? key, string? value)
     {
         if(!string.IsNullOrEmpty(key))
             throw new InvalidOperationException(TextParseNode.NoStructuredDataMessage);
@@ -90,11 +89,11 @@ public class TextSerializationWriter : ISerializationWriter, IDisposable {
             }
     }
     /// <inheritdoc />
-    public void WriteTimeSpanValue(string key, TimeSpan? value) => WriteStringValue(key, value.HasValue ? XmlConvert.ToString(value.Value) : null);
+    public void WriteTimeSpanValue(string? key, TimeSpan? value) => WriteStringValue(key, value.HasValue ? XmlConvert.ToString(value.Value) : null);
     /// <inheritdoc />
-    public void WriteTimeValue(string key, Time? value) => WriteStringValue(key, value?.ToString());
+    public void WriteTimeValue(string? key, Time? value) => WriteStringValue(key, value?.ToString());
     /// <inheritdoc />
-    void ISerializationWriter.WriteCollectionOfEnumValues<T>(string key, IEnumerable<T?> values) => throw new InvalidOperationException(TextParseNode.NoStructuredDataMessage);
+    void ISerializationWriter.WriteCollectionOfEnumValues<T>(string? key, IEnumerable<T?>? values) => throw new InvalidOperationException(TextParseNode.NoStructuredDataMessage);
     /// <inheritdoc />
-    void ISerializationWriter.WriteEnumValue<T>(string key, T? value) => WriteStringValue(key, value.HasValue ? value.Value.ToString().ToFirstCharacterLowerCase() : null);
+    void ISerializationWriter.WriteEnumValue<T>(string? key, T? value) => WriteStringValue(key, value.HasValue ? value.Value.ToString().ToFirstCharacterLowerCase() : null);
 }


### PR DESCRIPTION
This PR is part of https://github.com/microsoft/kiota/issues/2073

Changes include: -

- Adds nullable markers to APIs that can return null. 
- Adds nullable feature in project as well as net6.0 target to allow for proper feature functionality. Also sets `TreatWarningsAsErrors` to alleviate any potential mistakes being ignored.