### PR TITLE
Update DynamicallyAccessMembers for IParseNode Enum methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.1.4] - 2024-02-27
+
+### Changed
+
+- Reduced `DynamicallyAccessedMembers` scope for enum methods to prevent ILC warnings.
+
 ## [1.1.3] - 2024-02-26
 
 ### Changed

--- a/src/Microsoft.Kiota.Serialization.Text.csproj
+++ b/src/Microsoft.Kiota.Serialization.Text.csproj
@@ -13,7 +13,7 @@
     <PackageProjectUrl>https://aka.ms/kiota/docs</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.1.3</VersionPrefix>
+    <VersionPrefix>1.1.4</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <SignAssembly>false</SignAssembly>
@@ -42,7 +42,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.7.10" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.7.11" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">

--- a/src/TextParseNode.cs
+++ b/src/TextParseNode.cs
@@ -67,14 +67,14 @@ public class TextParseNode : IParseNode
     public Time? GetTimeValue() => DateTime.TryParse(Text, out var result) ? new Time(result) : null;
     /// <inheritdoc />
 #if NET5_0_OR_GREATER
-    public IEnumerable<T?> GetCollectionOfEnumValues<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>() where T : struct, Enum
+    public IEnumerable<T?> GetCollectionOfEnumValues<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>() where T : struct, Enum
 #else
     public IEnumerable<T?> GetCollectionOfEnumValues<T>() where T : struct, Enum
 #endif
     => throw new InvalidOperationException(NoStructuredDataMessage);
     /// <inheritdoc />
 #if NET5_0_OR_GREATER
-    public T? GetEnumValue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>() where T : struct, Enum
+    public T? GetEnumValue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>() where T : struct, Enum
 #else
     public T? GetEnumValue<T>() where T : struct, Enum
 #endif


### PR DESCRIPTION
Updates DynamicallyAccessMembers for IParseNode Enum methods to align with changes from https://github.com/microsoft/kiota-abstractions-dotnet/pull/202